### PR TITLE
Bundle yarn with nodejs

### DIFF
--- a/main/nodejs/checks.nix
+++ b/main/nodejs/checks.nix
@@ -4,14 +4,24 @@ let
   inherit (nixpkgs.stable.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.stable.testers) testEqualContents;
 
-  versionCheck = version: nodejs: testEqualContents {
+  checkNodejsVersion = version: package: testEqualContents {
     assertion = "nodejs is version ${version}";
     expected = writeText "expected" ("v" + version + "\n");
-    actual = runCommand "actual" { nativeBuildInputs = [ nodejs ]; } "node --version > $out";
+    actual = runCommand "actual" { nativeBuildInputs = [ package ]; } "node --version > $out";
+  };
+
+  checkYarnVersion = version: package: testEqualContents {
+    assertion = "yarn is version ${version}";
+    expected = writeText "expected" (version + "\n");
+    actual = runCommand "actual" { nativeBuildInputs = [ package ]; } "yarn --version > $out";
   };
 in
 {
-  nodejs-version-16-20-0 = versionCheck "16.20.0" packages.nodejs-16-20-0;
-  nodejs-version-16-20-1 = versionCheck "16.20.1" packages.nodejs-16-20-1;
-  nodejs-version-16-20-2 = versionCheck "16.20.2" packages.nodejs-16-20-2;
+  nodejs-16-20-0-version = checkNodejsVersion "16.20.0" packages.nodejs-16-20-0;
+  nodejs-16-20-1-version = checkNodejsVersion "16.20.1" packages.nodejs-16-20-1;
+  nodejs-16-20-2-version = checkNodejsVersion "16.20.2" packages.nodejs-16-20-2;
+
+  nodejs-16-20-0-yarn-version = checkYarnVersion "1.22.19" packages.nodejs-16-20-0;
+  nodejs-16-20-1-yarn-version = checkYarnVersion "1.22.19" packages.nodejs-16-20-1;
+  nodejs-16-20-2-yarn-version = checkYarnVersion "1.22.19" packages.nodejs-16-20-2;
 }

--- a/main/nodejs/default.nix
+++ b/main/nodejs/default.nix
@@ -1,9 +1,46 @@
 { nixpkgs }:
+let
+  inherit (nixpkgs.stable) symlinkJoin;
+in
+
 rec {
   nodejs-default = nodejs-16-x;
   nodejs-16-x = nodejs-16-20-x;
   nodejs-16-20-x = nodejs-16-20-2;
-  nodejs-16-20-0 = nixpkgs.master-2023-05-06.nodejs_16;
-  nodejs-16-20-1 = nixpkgs.master-2023-07-18.nodejs_16;
-  nodejs-16-20-2 = nixpkgs.stable.nodejs_16;
+
+  nodejs-16-20-0 = (
+    let
+      pkgs = nixpkgs.master-2023-05-06;
+      nodejs = pkgs.nodejs_16;
+      yarn = pkgs.yarn.override { inherit nodejs; };
+    in
+    symlinkJoin {
+      name = "nodejs";
+      paths = [ nodejs yarn ];
+    }
+  );
+
+  nodejs-16-20-1 = (
+    let
+      pkgs = nixpkgs.master-2023-07-18;
+      nodejs = pkgs.nodejs_16;
+      yarn = pkgs.yarn.override { inherit nodejs; };
+    in
+    symlinkJoin {
+      name = "nodejs";
+      paths = [ nodejs yarn ];
+    }
+  );
+
+  nodejs-16-20-2 = (
+    let
+      pkgs = nixpkgs.stable;
+      nodejs = pkgs.nodejs_16;
+      yarn = pkgs.yarn.override { inherit nodejs; };
+    in
+    symlinkJoin {
+      name = "nodejs";
+      paths = [ nodejs yarn ];
+    }
+  );
 }


### PR DESCRIPTION
I haven't come up with any better way to provide yarn, because it seems to be rather linked to the nodejs version. It seems reasonable enough to just bundle it into the nodejs package, so if you request nodejs, you get both nodejs and yarn.

(It seems like this yarn version is quite behind the times, but it's all nixpkgs has at the moment, and I've been using it with no issues.)