### PR TITLE
upgrade stable input to 23.11

### DIFF
--- a/main/aws-cli/checks.nix
+++ b/main/aws-cli/checks.nix
@@ -17,4 +17,5 @@ let
 in
 {
   aws-cli-2-11-20 = versionCheck "2.11.20" packages.aws-cli-2-11-20;
+  aws-cli-2-13-33 = versionCheck "2.13.33" packages.aws-cli-2-13-33;
 }

--- a/main/aws-cli/packages.nix
+++ b/main/aws-cli/packages.nix
@@ -1,10 +1,19 @@
 { inputs, system, ... }:
-let
-  nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
-in
 rec {
   aws-cli-default = aws-cli-2-x;
-  aws-cli-2-x = aws-cli-2-11-x;
+  aws-cli-2-x = aws-cli-2-13-x;
+
   aws-cli-2-11-x = aws-cli-2-11-20;
-  aws-cli-2-11-20 = nixpkgs.awscli2;
+  aws-cli-2-11-20 =
+    let
+      nixpkgs = import inputs.nixpkgs-23-05 { inherit system; config = { }; };
+    in
+    nixpkgs.awscli2;
+
+  aws-cli-2-13-x = aws-cli-2-13-33;
+  aws-cli-2-13-33 =
+    let
+      nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
+    in
+    nixpkgs.awscli2;
 }

--- a/main/flake.lock
+++ b/main/flake.lock
@@ -18,6 +18,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-23-05": {
+      "locked": {
+        "lastModified": 1701362232,
+        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-master-2023-05-06": {
       "locked": {
         "lastModified": 1683392273,
@@ -68,16 +84,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1697226376,
-        "narHash": "sha256-cumLLb1QOUtWieUnLGqo+ylNt3+fU8Lcv5Zl+tYbRUE=",
+        "lastModified": 1701263465,
+        "narHash": "sha256-lNXUIlkfyDyp9Ox21hr+wsEf/IBklLvb6bYcyeXbdRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "898cb2064b6e98b8c5499f37e81adbdf2925f7c5",
+        "rev": "50aa30a13c4ab5e7ba282da460a3e3d44e9d0eb3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -117,6 +133,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgs-23-05": "nixpkgs-23-05",
         "nixpkgs-master-2023-05-06": "nixpkgs-master-2023-05-06",
         "nixpkgs-master-2023-07-18": "nixpkgs-master-2023-07-18",
         "nixpkgs-master-2023-09-15": "nixpkgs-master-2023-09-15",

--- a/main/flake.nix
+++ b/main/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-23.05";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs-23-05.url = "github:nixos/nixpkgs/nixos-23.05";
     nixpkgs-stable-2023-07-25.url = "github:nixos/nixpkgs/6dc93f0daec55ee2f441da385aaf143863e3d671";
     nixpkgs-master-2023-05-06.url = "github:nixos/nixpkgs/16b3b0c53b1ee8936739f8c588544e7fcec3fc60";
     nixpkgs-master-2023-07-18.url = "github:nixos/nixpkgs/08700de174bc6235043cb4263b643b721d936bdb";

--- a/main/ghc/checks.nix
+++ b/main/ghc/checks.nix
@@ -25,8 +25,10 @@ in
   ghc-9-2-7 = ghcVersionCheck "9.2.7" packages.ghc-9-2-7;
   ghc-9-2-8 = ghcVersionCheck "9.2.8" packages.ghc-9-2-8;
   ghc-9-4-6 = ghcVersionCheck "9.4.6" packages.ghc-9-4-6;
+  ghc-9-4-7 = ghcVersionCheck "9.4.7" packages.ghc-9-4-7;
 
   weeder-for-ghc-9-2-7 = weederVersionCheck "2.4.1" packages.ghc-9-2-7;
   weeder-for-ghc-9-2-8 = weederVersionCheck "2.4.1" packages.ghc-9-2-8;
   weeder-for-ghc-9-4-6 = weederVersionCheck "2.5.0" packages.ghc-9-4-6;
+  weeder-for-ghc-9-4-7 = weederVersionCheck "2.7.0" packages.ghc-9-4-7;
 }

--- a/main/ghc/configurations.nix
+++ b/main/ghc/configurations.nix
@@ -29,8 +29,20 @@ in
 
   ghc-9-4-6 = { packageSelection }:
     let
-      nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
+      nixpkgs = import inputs.nixpkgs-23-05 { inherit system; config = { }; };
       name = "ghc946";
+      inherit (nixpkgs) haskell;
+      haskellPackages = haskell.packages.${name};
+      ghcWithPackages = haskellPackages.ghcWithPackages packageSelection;
+      inherit (haskell.lib) justStaticExecutables;
+      weeder = justStaticExecutables haskellPackages.weeder;
+    in
+    symlinkJoin { inherit name; paths = [ ghcWithPackages weeder ]; };
+
+  ghc-9-4-7 = { packageSelection }:
+    let
+      nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
+      name = "ghc947";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
       ghcWithPackages = haskellPackages.ghcWithPackages packageSelection;

--- a/main/nodejs/checks.nix
+++ b/main/nodejs/checks.nix
@@ -22,6 +22,7 @@ let
     expected = writeText "expected" (version + "\n");
     actual = runCommand "actual" { nativeBuildInputs = [ package ]; } "pnpm --version > $out";
   };
+
 in
 {
   nodejs-16-20-0-version = checkNodejsVersion "16.20.0" packages.nodejs-16-20-0;

--- a/main/nodejs/v16.nix
+++ b/main/nodejs/v16.nix
@@ -50,7 +50,7 @@ rec {
 
   nodejs-16-20-2 = (
     let
-      nixpkgs = import inputs.nixpkgs-stable {
+      nixpkgs = import inputs.nixpkgs-23-05 {
         inherit system; config = {
         permittedInsecurePackages = [
           "nodejs-16.20.2"

--- a/main/prettier/checks.nix
+++ b/main/prettier/checks.nix
@@ -15,4 +15,5 @@ let
 in
 {
   prettier-2-8-8 = versionCheck "2.8.8" packages.prettier-2-8-8;
+  prettier-3-0-3 = versionCheck "3.0.3" packages.prettier-3-0-3;
 }

--- a/main/prettier/packages.nix
+++ b/main/prettier/packages.nix
@@ -1,10 +1,18 @@
 { inputs, system, ... }:
-let
-  nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
-in
 rec {
-  prettier-default = prettier-2-8-8;
+  prettier-default = prettier-3-x;
   prettier-2-x = prettier-2-8-x;
   prettier-2-8-x = prettier-2-8-8;
-  prettier-2-8-8 = nixpkgs.nodePackages.prettier;
+  prettier-2-8-8 =
+    let
+      nixpkgs = import inputs.nixpkgs-23-05 { inherit system; config = { }; };
+    in
+    nixpkgs.nodePackages.prettier;
+  prettier-3-x = prettier-3-0-x;
+  prettier-3-0-x = prettier-3-0-3;
+  prettier-3-0-3 =
+    let
+      nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
+    in
+    nixpkgs.nodePackages.prettier;
 }


### PR DESCRIPTION
This changes the input named "nixpkgs-stable" to point to the latest LTS release (23.11), and introduces a new input "nixpkgs-23-05" for particular versions of packages that need to be held back. New versions of some packages have been introduced based on what's in 23.11.