### PR TITLE
switch ghc 9.2.8 to the stable channel

### DIFF
--- a/main/ghc/checks.nix
+++ b/main/ghc/checks.nix
@@ -53,7 +53,7 @@ in
   weeder-for-ghc-9-6-5 = weederVersionCheck "2.8.0" packages.ghc-9-6-5;
 
   hls-for-ghc-9-2-7 = hlsVersionCheck "1.10.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-2-7"; enableHLS = true; });
-  hls-for-ghc-9-2-8 = hlsVersionCheck "2.2.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-2-8"; enableHLS = true; });
+  hls-for-ghc-9-2-8 = hlsVersionCheck "2.4.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-2-8"; enableHLS = true; });
   hls-for-ghc-9-4-5 = hlsVersionCheck "2.4.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-4-5"; enableHLS = true; });
   hls-for-ghc-9-4-6 = hlsVersionCheck "2.4.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-4-6"; enableHLS = true; });
   hls-for-ghc-9-4-7 = hlsVersionCheck "2.4.0.0" (lib.haskellBundle { ghcVersion = "ghc-9-4-7"; enableHLS = true; });

--- a/main/ghc/configurations.nix
+++ b/main/ghc/configurations.nix
@@ -37,7 +37,7 @@ in
 
   ghc-9-2-8 = { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-unstable-2023-10-21 { inherit system; config = { }; };
+      nixpkgs = import inputs.nixpkgs-stable { inherit system; config = { }; };
       name = "ghc928";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};


### PR DESCRIPTION
iirc it just wasn't available in a stable channel yet when I first added it.

GHC 9.2.8 still doesn't seem to work very well, though. I can't build megarepo/backend with it.