### PR TITLE
Get docker from nixos 24.05

### DIFF
--- a/main/flake.nix
+++ b/main/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
     nixpkgs-22-11.url = "github:nixos/nixpkgs/nixos-22.11";
     nixpkgs-23-05.url = "github:nixos/nixpkgs/nixos-23.05";
     nixpkgs-23-11.url = "github:nixos/nixpkgs/nixos-23.11";

--- a/main/nixos-modules.nix
+++ b/main/nixos-modules.nix
@@ -3,7 +3,7 @@
   docker-for-local-dev =
     { config, ... }:
     let
-      pkgs = import inputs.nixpkgs-22-11 { inherit (config.nixpkgs) system; };
+      pkgs = import inputs.nixpkgs-24-05 { inherit (config.nixpkgs) system; };
     in
     {
       # Enable Docker


### PR DESCRIPTION
Alternative to #44, gets docker from the latest NixOS release.