### PR TITLE
Automatically run 'nix flake update'

### DIFF
--- a/.github/workflows/educator-client-gen.yml
+++ b/.github/workflows/educator-client-gen.yml
@@ -1,0 +1,25 @@
+name: Update flake inputs
+
+on:
+  schedule:
+    - cron: "* * * * 6"
+
+defaults:
+  run:
+    working-directory: main
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v26
+      - name: Update
+        run: nix flake update
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          branch: gh/update
+          title: Update flake inputs
+          body: |
+            Automatic run of `nix flake update`.
+          token: ${{ secrets.FRECKLE_AUTOMATION_GITHUB_TOKEN }}


### PR DESCRIPTION
This should generate a PR every Saturday to update the flake lock file, to help us stay up to date with the latest versions of Nix channels and any other inputs that are tracking branch heads (rather than being tagged to particular versions). Experimental!