### PR TITLE
upgrade macos 12->13

### DIFF
--- a/main/flake.nix
+++ b/main/flake.nix
@@ -50,7 +50,7 @@
         checks = inputs.nixpkgs-stable.lib.getAttrs systems inputs.self.checks;
         platforms = {
           "x86_64-linux" = "ubuntu-22.04";
-          "x86_64-darwin" = "macos-12";
+          "x86_64-darwin" = "macos-13";
           "aarch64-darwin" = "macos-14";
         };
       };


### PR DESCRIPTION
Shutdown of [macos-12](https://github.com/actions/runner-images/issues/10721) support has begun.