### PR TITLE
upgrade stack-lint-extra-deps

### DIFF
--- a/main/flake.lock
+++ b/main/flake.lock
@@ -488,53 +488,21 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1722185531,
-        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
+        "lastModified": 1733756863,
+        "narHash": "sha256-gbivEqdl62NnnESKvRiUR+GRhCGrf1mUoNtGl/yYu4k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
+        "rev": "06886d32c517d0e199c0e6d345d54673acc55453",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1722185531,
-        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "pgp-wordlist": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714149562,
-        "narHash": "sha256-WCFQgtWqq+gLst4lXkFYlmlW7L8PQOJfChsKMApy3Ng=",
-        "owner": "quchen",
-        "repo": "pgp-wordlist",
-        "rev": "1f0cfd90d62179952cbfd59c3405283a1d364272",
-        "type": "github"
-      },
-      "original": {
-        "owner": "quchen",
-        "repo": "pgp-wordlist",
-        "type": "github"
-      }
-    },
-    "pgp-wordlist_2": {
       "flake": false,
       "locked": {
         "lastModified": 1714149562,
@@ -595,8 +563,7 @@
         "nixpkgs-unstable-2024-04-03": "nixpkgs-unstable-2024-04-03",
         "nixpkgs-unstable-2024-05-30": "nixpkgs-unstable-2024-05-30",
         "nixpkgs-unstable-2024-07-29": "nixpkgs-unstable-2024-07-29",
-        "stack-lint-extra-deps": "stack-lint-extra-deps",
-        "stack-lint-extra-deps-1-2-2": "stack-lint-extra-deps-1-2-2"
+        "stack-lint-extra-deps": "stack-lint-extra-deps"
       }
     },
     "safe-coloured-text": {
@@ -622,62 +589,26 @@
         "stacklock2nix": "stacklock2nix"
       },
       "locked": {
-        "lastModified": 1733313314,
-        "narHash": "sha256-9HAmABc+lYe2HnYdcMh/x/UTlmq36km3cvqMPAdZkfg=",
+        "lastModified": 1734039705,
+        "narHash": "sha256-fM6/erR1M+QA0XJ09IrncP4e+HbKkkVNBPuzcFirYY0=",
         "owner": "freckle",
         "repo": "stack-lint-extra-deps",
-        "rev": "18bb6cade3ebc8c5b0aca38da75f5c717fa2d467",
+        "rev": "a5a2596ad473fb330b6fa3b89e28f3f1254df0d6",
         "type": "github"
       },
       "original": {
         "owner": "freckle",
         "repo": "stack-lint-extra-deps",
-        "type": "github"
-      }
-    },
-    "stack-lint-extra-deps-1-2-2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_4",
-        "pgp-wordlist": "pgp-wordlist_2",
-        "stacklock2nix": "stacklock2nix_2"
-      },
-      "locked": {
-        "lastModified": 1723061685,
-        "narHash": "sha256-11XpTeXmjUBgK3dOk9+9Mwb0EbtKTTl9AZU6hPXtP2Q=",
-        "owner": "freckle",
-        "repo": "stack-lint-extra-deps",
-        "rev": "0dccbb297a4bdc01509e2e18c8e3f726014bc35a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "freckle",
-        "repo": "stack-lint-extra-deps",
-        "rev": "0dccbb297a4bdc01509e2e18c8e3f726014bc35a",
         "type": "github"
       }
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1705051190,
-        "narHash": "sha256-xgH0gaD3dNtOzZzX3A40hZTiHJP5cIGmifbmfcS2OGI=",
+        "lastModified": 1731366632,
+        "narHash": "sha256-dd10Hyqbyhg83pgxE8Sl1jo9wdYzTU4muH83TjhyrCY=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "22676dfc45fa1c33899ba1da1a23665172a18ba7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "type": "github"
-      }
-    },
-    "stacklock2nix_2": {
-      "locked": {
-        "lastModified": 1705051190,
-        "narHash": "sha256-xgH0gaD3dNtOzZzX3A40hZTiHJP5cIGmifbmfcS2OGI=",
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "rev": "22676dfc45fa1c33899ba1da1a23665172a18ba7",
+        "rev": "3cb77e9c869be90ad939f368096ff2cc940881d4",
         "type": "github"
       },
       "original": {

--- a/main/flake.nix
+++ b/main/flake.nix
@@ -19,7 +19,6 @@
     nixpkgs-unstable-2024-05-30.url = "github:nixos/nixpkgs/aa61b27554a5fc282758bf0324781e3464ef2cde";
     nixpkgs-unstable-2024-07-29.url = "github:nixos/nixpkgs/038fb464fcfa79b4f08131b07f2d8c9a6bcc4160";
     stack-lint-extra-deps.url = "github:freckle/stack-lint-extra-deps";
-    stack-lint-extra-deps-1-2-2.url = "github:freckle/stack-lint-extra-deps/0dccbb297a4bdc01509e2e18c8e3f726014bc35a";
     nixpkgs-haskell-updates.url = "github:nixos/nixpkgs/haskell-updates";
     flake-utils.url = "github:numtide/flake-utils";
     nix-github-actions.url = "github:nix-community/nix-github-actions";

--- a/main/stack-lint-extra-deps/checks.nix
+++ b/main/stack-lint-extra-deps/checks.nix
@@ -26,4 +26,5 @@ in
 {
   stack-lint-extra-deps-1-2-2 = versionCheck "1.2.2.1" packages.stack-lint-extra-deps-1-2-2;
   stack-lint-extra-deps-1-2-5 = versionCheck "1.2.5.0" packages.stack-lint-extra-deps-1-2-5;
+  stack-lint-extra-deps-1-3-0 = versionCheck "1.3.0.0" packages.stack-lint-extra-deps-1-3-0;
 }

--- a/main/stack-lint-extra-deps/packages.nix
+++ b/main/stack-lint-extra-deps/packages.nix
@@ -1,16 +1,23 @@
 { inputs, system, ... }:
 let
-  nixpkgs = import inputs.nixpkgs-stable { inherit system; };
+  nixpkgs = import inputs.nixpkgs-24-11 { inherit system; };
   inherit (nixpkgs.haskell.lib) justStaticExecutables;
+  inherit (builtins) getFlake;
 in
 rec {
-  stack-lint-extra-deps-default = stack-lint-extra-deps-1-2-5;
+  stack-lint-extra-deps-default = stack-lint-extra-deps-1-3-0;
 
   stack-lint-extra-deps-1-2-2 =
     justStaticExecutables
-      inputs.stack-lint-extra-deps-1-2-2.packages.${system}.stack-lint-extra-deps;
+      (getFlake "github:freckle/stack-lint-extra-deps/0dccbb297a4bdc01509e2e18c8e3f726014bc35a")
+      .packages.${system}.stack-lint-extra-deps;
 
   stack-lint-extra-deps-1-2-5 =
+    justStaticExecutables
+      (getFlake "github:freckle/stack-lint-extra-deps/18bb6cade3ebc8c5b0aca38da75f5c717fa2d467")
+      .packages.${system}.stack-lint-extra-deps;
+
+  stack-lint-extra-deps-1-3-0 =
     justStaticExecutables
       inputs.stack-lint-extra-deps.packages.${system}.stack-lint-extra-deps;
 }


### PR DESCRIPTION
Adds SLED version 1.3.

It [took some doing](https://github.com/freckle/stack-lint-extra-deps/pull/54) to figure out why it wasn't working for MacOS x86_64.

Also - I realized that when we're depending on a fixed revision that we don't intent to upgrade, e.g. for building older versions of SLED here, I don't think there's any reason to go use `flake.nix` inputs for them. We can instead use the `getFlake` function, closer to where that input is used.