### PR TITLE
separate automatic update PRs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,11 +12,24 @@ defaults:
 jobs:
   update:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        input:
+          - flake-utils
+          - haskell-openapi-code-generator
+          - nix-github-actions
+          - nixpkgs-22-11
+          - nixpkgs-23-05
+          - nixpkgs-23-11
+          - nixpkgs-24-05
+          - nixpkgs-24-11
+          - nixpkgs-haskell-updates
+          - stack-lint-extra-deps
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v26
       - name: Update
-        run: nix flake update --accept-flake-config
+        run: nix flake lock --accept-flake-config --update-input ${{ matrix.input }}
 
       # Use a PAT so that Workflows run on the created PR
       - id: token
@@ -27,8 +40,8 @@ jobs:
 
       - uses: peter-evans/create-pull-request@v6
         with:
-          branch: gh/update
-          title: Update flake inputs
+          branch: gh/update-${{ matrix.input }}
+          title: Update ${{ matrix.input }}
           body: |
-            Automatic run of `nix flake update`.
+            Automatic update of flake input ${{ matrix.input }}
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
`nix flake update` tries to update all the flake inputs at once. This changes the automatic updater to instead do `nix flake lock --update-input ...` for each of input individually and create a separate PR for each thing that needs updating, which should make it easier to keep most things up to date since one problematic upgrade won't block everything.