### PR TITLE
don't use pinned commits as flake.nix inputs, and don't 'import' nixpkgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,6 @@ jobs:
           name: freckle
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check
-        run: nix build --accept-flake-config --print-build-logs --keep-going "./main#${{ matrix.attr }}"
+        run: nix build --accept-flake-config --print-build-logs --keep-going --impure "./main#${{ matrix.attr }}"
+        env:
+          NIXPKGS_ALLOW_INSECURE: "1"

--- a/main/aws-cli/checks.nix
+++ b/main/aws-cli/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/aws-cli/packages.nix
+++ b/main/aws-cli/packages.nix
@@ -4,32 +4,11 @@ rec {
   aws-cli-2-x = aws-cli-2-15-x;
 
   aws-cli-2-11-x = aws-cli-2-11-20;
-  aws-cli-2-11-20 =
-    let
-      nixpkgs = import inputs.nixpkgs-23-05 {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.awscli2;
+  aws-cli-2-11-20 = inputs.nixpkgs-23-05.legacyPackages.${system}.awscli2;
 
   aws-cli-2-13-x = aws-cli-2-13-33;
-  aws-cli-2-13-33 =
-    let
-      nixpkgs = import inputs.nixpkgs-23-11 {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.awscli2;
+  aws-cli-2-13-33 = inputs.nixpkgs-23-11.legacyPackages.${system}.awscli2;
 
   aws-cli-2-15-x = aws-cli-2-15-43;
-  aws-cli-2-15-43 =
-    let
-      nixpkgs = import inputs.nixpkgs-stable {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.awscli2;
+  aws-cli-2-15-43 = inputs.nixpkgs-stable.legacyPackages.${system}.awscli2;
 }

--- a/main/checks.nix
+++ b/main/checks.nix
@@ -5,10 +5,7 @@
   lib,
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   flattenAttrs = nixpkgs.lib.lists.foldl' (a: b: a // b) { };
   files = [
     ./aws-cli/checks.nix

--- a/main/cypress/checks.nix
+++ b/main/cypress/checks.nix
@@ -7,10 +7,7 @@
 {
   "x86_64-linux" =
     let
-      nixpkgs = import inputs.nixpkgs-stable {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
       inherit (nixpkgs) writeText runCommand;
       inherit (nixpkgs.lib.attrsets) recursiveUpdate;
       inherit (nixpkgs.testers) testEqualContents;

--- a/main/cypress/packages.nix
+++ b/main/cypress/packages.nix
@@ -3,10 +3,7 @@ let
   makeCypress =
     { version, sha256 }:
     let
-      nixpkgs = import inputs.nixpkgs-stable {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
     in
     nixpkgs.cypress.overrideAttrs (oldAttrs: rec {
       pname = "cypress";

--- a/main/flake.lock
+++ b/main/flake.lock
@@ -246,102 +246,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-master-2023-05-06": {
-      "locked": {
-        "lastModified": 1683392273,
-        "narHash": "sha256-pZTuxvcuDeBG+vvE1zczNyEUzlPbzXVh8Ed45Fzo+tQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "16b3b0c53b1ee8936739f8c588544e7fcec3fc60",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "16b3b0c53b1ee8936739f8c588544e7fcec3fc60",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master-2023-07-18": {
-      "locked": {
-        "lastModified": 1689680872,
-        "narHash": "sha256-brNix2+ihJSzCiKwLafbyejrHJZUP0Fy6z5+xMOC27M=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "08700de174bc6235043cb4263b643b721d936bdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "08700de174bc6235043cb4263b643b721d936bdb",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master-2023-09-15": {
-      "locked": {
-        "lastModified": 1694760568,
-        "narHash": "sha256-3G07BiXrp2YQKxdcdms22MUx6spc6A++MSePtatCYuI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "46688f8eb5cd6f1298d873d4d2b9cf245e09e88e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "46688f8eb5cd6f1298d873d4d2b9cf245e09e88e",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master-2024-01-27": {
-      "locked": {
-        "lastModified": 1706367331,
-        "narHash": "sha256-AqgkGHRrI6h/8FWuVbnkfFmXr4Bqsr4fV23aISqj/xg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "160b762eda6d139ac10ae081f8f78d640dd523eb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "160b762eda6d139ac10ae081f8f78d640dd523eb",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master-2024-10-19": {
-      "locked": {
-        "lastModified": 1729399009,
-        "narHash": "sha256-mZXm1ka9mKh5L9Cu3rDvSwu0SEclA4tRcINI2SrIl1I=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "67f803dcf82ebe958a53fcfa7c1edb276558c3f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "67f803dcf82ebe958a53fcfa7c1edb276558c3f6",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master-2024-12-11": {
-      "locked": {
-        "lastModified": 1733943644,
-        "narHash": "sha256-QwvhflHNKXDAizcr94craTItdMBBNx7asuJenZoxThs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f11a40c4201996d9aae5a99790fb6a172df114bb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f11a40c4201996d9aae5a99790fb6a172df114bb",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1720386169,
@@ -358,22 +262,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable-2023-07-25": {
-      "locked": {
-        "lastModified": 1690271650,
-        "narHash": "sha256-qwdsW8DBY1qH+9luliIH7VzgwvL+ZGI3LZWC0LTiDMI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "6dc93f0daec55ee2f441da385aaf143863e3d671",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "6dc93f0daec55ee2f441da385aaf143863e3d671",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1730883749,
@@ -387,86 +275,6 @@
         "owner": "nixos",
         "ref": "nixos-24.05",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable-2023-10-21": {
-      "locked": {
-        "lastModified": 1697793076,
-        "narHash": "sha256-02e7sCuqLtkyRgrZmdOyvAcQTQdcXj+vpyp9bca6cY4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "038b2922be3fc096e1d456f93f7d0f4090628729",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "038b2922be3fc096e1d456f93f7d0f4090628729",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable-2024-02-20": {
-      "locked": {
-        "lastModified": 1708296515,
-        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable-2024-04-03": {
-      "locked": {
-        "lastModified": 1712143413,
-        "narHash": "sha256-kI6WYXuj8/2AtBF4o0gYnkYNO1xtc6PaPbW/qmaV67A=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "62e885a4013446453b10fd7780eba4337f6f42e0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "62e885a4013446453b10fd7780eba4337f6f42e0",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable-2024-05-30": {
-      "locked": {
-        "lastModified": 1717070961,
-        "narHash": "sha256-0JN98HVWPMlxj48Ot9K3eF0CWfwvo7/7VAYO+VAHg1Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "aa61b27554a5fc282758bf0324781e3464ef2cde",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "aa61b27554a5fc282758bf0324781e3464ef2cde",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable-2024-07-29": {
-      "locked": {
-        "lastModified": 1722141560,
-        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
         "type": "github"
       }
     },
@@ -550,19 +358,7 @@
         "nixpkgs-24-05": "nixpkgs-24-05",
         "nixpkgs-24-11": "nixpkgs-24-11",
         "nixpkgs-haskell-updates": "nixpkgs-haskell-updates",
-        "nixpkgs-master-2023-05-06": "nixpkgs-master-2023-05-06",
-        "nixpkgs-master-2023-07-18": "nixpkgs-master-2023-07-18",
-        "nixpkgs-master-2023-09-15": "nixpkgs-master-2023-09-15",
-        "nixpkgs-master-2024-01-27": "nixpkgs-master-2024-01-27",
-        "nixpkgs-master-2024-10-19": "nixpkgs-master-2024-10-19",
-        "nixpkgs-master-2024-12-11": "nixpkgs-master-2024-12-11",
         "nixpkgs-stable": "nixpkgs-stable_2",
-        "nixpkgs-stable-2023-07-25": "nixpkgs-stable-2023-07-25",
-        "nixpkgs-unstable-2023-10-21": "nixpkgs-unstable-2023-10-21",
-        "nixpkgs-unstable-2024-02-20": "nixpkgs-unstable-2024-02-20",
-        "nixpkgs-unstable-2024-04-03": "nixpkgs-unstable-2024-04-03",
-        "nixpkgs-unstable-2024-05-30": "nixpkgs-unstable-2024-05-30",
-        "nixpkgs-unstable-2024-07-29": "nixpkgs-unstable-2024-07-29",
         "stack-lint-extra-deps": "stack-lint-extra-deps"
       }
     },

--- a/main/flake.nix
+++ b/main/flake.nix
@@ -1,29 +1,17 @@
 {
   inputs = {
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
-    nixpkgs-24-11.url = "github:nixos/nixpkgs/nixos-24.11";
-    nixpkgs-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    haskell-openapi-code-generator.url = "github:Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator";
+    nix-github-actions.inputs.nixpkgs.follows = "nixpkgs-stable";
+    nix-github-actions.url = "github:nix-community/nix-github-actions";
     nixpkgs-22-11.url = "github:nixos/nixpkgs/nixos-22.11";
     nixpkgs-23-05.url = "github:nixos/nixpkgs/nixos-23.05";
     nixpkgs-23-11.url = "github:nixos/nixpkgs/nixos-23.11";
-    nixpkgs-stable-2023-07-25.url = "github:nixos/nixpkgs/6dc93f0daec55ee2f441da385aaf143863e3d671";
-    nixpkgs-master-2023-05-06.url = "github:nixos/nixpkgs/16b3b0c53b1ee8936739f8c588544e7fcec3fc60";
-    nixpkgs-master-2023-07-18.url = "github:nixos/nixpkgs/08700de174bc6235043cb4263b643b721d936bdb";
-    nixpkgs-master-2023-09-15.url = "github:nixos/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e";
-    nixpkgs-master-2024-01-27.url = "github:nixos/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb";
-    nixpkgs-master-2024-10-19.url = "github:nixos/nixpkgs/67f803dcf82ebe958a53fcfa7c1edb276558c3f6";
-    nixpkgs-master-2024-12-11.url = "github:nixos/nixpkgs/f11a40c4201996d9aae5a99790fb6a172df114bb";
-    nixpkgs-unstable-2023-10-21.url = "github:nixos/nixpkgs/038b2922be3fc096e1d456f93f7d0f4090628729";
-    nixpkgs-unstable-2024-02-20.url = "github:nixos/nixpkgs/b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa";
-    nixpkgs-unstable-2024-04-03.url = "github:nixos/nixpkgs/62e885a4013446453b10fd7780eba4337f6f42e0";
-    nixpkgs-unstable-2024-05-30.url = "github:nixos/nixpkgs/aa61b27554a5fc282758bf0324781e3464ef2cde";
-    nixpkgs-unstable-2024-07-29.url = "github:nixos/nixpkgs/038fb464fcfa79b4f08131b07f2d8c9a6bcc4160";
-    stack-lint-extra-deps.url = "github:freckle/stack-lint-extra-deps";
+    nixpkgs-24-05.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs-24-11.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs-haskell-updates.url = "github:nixos/nixpkgs/haskell-updates";
-    flake-utils.url = "github:numtide/flake-utils";
-    nix-github-actions.url = "github:nix-community/nix-github-actions";
-    nix-github-actions.inputs.nixpkgs.follows = "nixpkgs-stable";
-    haskell-openapi-code-generator.url = "github:Haskell-OpenAPI-Code-Generator/Haskell-OpenAPI-Client-Code-Generator";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
+    stack-lint-extra-deps.url = "github:freckle/stack-lint-extra-deps";
   };
   outputs =
     inputs:

--- a/main/fourmolu/checks.nix
+++ b/main/fourmolu/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/fourmolu/packages.nix
+++ b/main/fourmolu/packages.nix
@@ -5,14 +5,14 @@
   ...
 }:
 let
+  inherit (builtins) getFlake;
+
   versions = v0-13 // v0-14 // v0-16 // { fourmolu-default = versions.fourmolu-0-13-x; };
 
   v0-13 =
     let
-      nixpkgs = import inputs.nixpkgs-stable-2023-07-25 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2023-07-25
+        (getFlake "github:nixos/nixpkgs/6dc93f0daec55ee2f441da385aaf143863e3d671").legacyPackages.${system};
       inherit (nixpkgs) haskell;
       inherit (haskell.lib) justStaticExecutables overrideCabal;
     in
@@ -46,10 +46,7 @@ let
 
   v0-14 =
     let
-      nixpkgs = import inputs.nixpkgs-stable {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
       inherit (nixpkgs) haskell;
       inherit (haskell.lib) justStaticExecutables overrideCabal;
     in
@@ -71,10 +68,7 @@ let
 
   v0-16 =
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       inherit (nixpkgs) haskell;
       inherit (haskell.lib) justStaticExecutables overrideCabal;
     in

--- a/main/ghc/checks.nix
+++ b/main/ghc/checks.nix
@@ -6,10 +6,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/ghc/configurations.nix
+++ b/main/ghc/configurations.nix
@@ -1,12 +1,8 @@
 { inputs, system }:
 let
-  inherit
-    (import inputs.nixpkgs-stable {
-      inherit system;
-      config = { };
-    })
-    symlinkJoin
-    ;
+  inherit (builtins) getFlake;
+
+  inherit (inputs.nixpkgs-stable.legacyPackages.${system}) symlinkJoin;
 
   addPatches = patches: prev: { patches = (prev.patches or [ ]) ++ patches; };
 
@@ -25,11 +21,13 @@ in
   ghc-9-2-7 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-stable-2023-07-25 {
-        inherit system;
-        config = { };
-        overlays = [ (ghcOverlay "ghc927" (addPatches [ ./sanity-check-find-file-name.patch ])) ];
-      };
+      overlays = [
+        (ghcOverlay "ghc927" (addPatches [ ./sanity-check-find-file-name.patch ]))
+      ];
+      nixpkgs = # 2023-07-25
+        (getFlake "github:nixos/nixpkgs/6dc93f0daec55ee2f441da385aaf143863e3d671")
+        .legacyPackages.${system}.appendOverlays
+          overlays;
       name = "ghc927";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -53,10 +51,7 @@ in
   ghc-9-2-8 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc928";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -80,10 +75,7 @@ in
   ghc-9-4-5 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc945";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -107,10 +99,7 @@ in
   ghc-9-4-6 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc946";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -134,10 +123,7 @@ in
   ghc-9-4-7 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc947";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -161,10 +147,7 @@ in
   ghc-9-4-8 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc948";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -188,10 +171,7 @@ in
   ghc-9-6-3 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc963";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -215,10 +195,7 @@ in
   ghc-9-6-4 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc964";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -242,10 +219,7 @@ in
   ghc-9-6-5 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc965";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -269,10 +243,7 @@ in
   ghc-9-6-6 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc966";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -296,10 +267,7 @@ in
   ghc-9-8-1 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc981";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -323,10 +291,7 @@ in
   ghc-9-8-2 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc982";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -350,10 +315,7 @@ in
   ghc-9-8-3 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc983";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -377,10 +339,7 @@ in
   ghc-9-8-4 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-haskell-updates {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-haskell-updates.legacyPackages.${system};
       name = "ghc984";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -389,12 +348,7 @@ in
       weeder = justStaticExecutables haskellPackages.weeder;
       hls = nixpkgs.haskell-language-server.override { supportedGhcVersions = [ "984" ]; };
       cabal = nixpkgs.cabal-install;
-      stack = import ./stack.nix {
-        nixpkgs = import inputs.nixpkgs-24-11 {
-          inherit system;
-          config = { };
-        };
-      };
+      stack = import ./stack.nix { nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system}; };
     in
     symlinkJoin {
       inherit name;
@@ -409,10 +363,7 @@ in
   ghc-9-10-1 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = import inputs.nixpkgs-24-11 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
       name = "ghc9101";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};

--- a/main/ghc/packages.nix
+++ b/main/ghc/packages.nix
@@ -1,9 +1,6 @@
 { inputs, system, ... }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   configurations = import ./configurations.nix { inherit inputs system; };
   applyDefaultVersions = import ./default-versions-function.nix;
   configurationToPackage =

--- a/main/haskell-openapi3-code-generator/checks.nix
+++ b/main/haskell-openapi3-code-generator/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/lib.nix
+++ b/main/lib.nix
@@ -4,10 +4,7 @@
   system,
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   flattenAttrs = nixpkgs.lib.lists.foldl' (a: b: a // b) { };
   files = [ ./ghc/lib.nix ];
 in

--- a/main/locize-cli/8.0.1/default.nix
+++ b/main/locize-cli/8.0.1/default.nix
@@ -1,9 +1,6 @@
 { inputs, system }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs)
     fetchFromGitHub
     mkYarnPackage

--- a/main/locize-cli/checks.nix
+++ b/main/locize-cli/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/nodejs/checks.nix
+++ b/main/nodejs/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/nodejs/v16.nix
+++ b/main/nodejs/v16.nix
@@ -1,13 +1,7 @@
 { inputs, system, ... }:
 let
-  inherit
-    (import inputs.nixpkgs-stable {
-      inherit system;
-      config = { };
-    })
-    symlinkJoin
-    runCommand
-    ;
+  inherit (builtins) getFlake;
+  inherit (inputs.nixpkgs-stable.legacyPackages.${system}) symlinkJoin runCommand;
 in
 rec {
   nodejs-16-x = nodejs-16-20-x;
@@ -15,10 +9,8 @@ rec {
 
   nodejs-16-20-0 = (
     let
-      nixpkgs = import inputs.nixpkgs-master-2023-05-06 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2023-05-06
+        (getFlake "github:nixos/nixpkgs/16b3b0c53b1ee8936739f8c588544e7fcec3fc60").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_16;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -41,12 +33,8 @@ rec {
 
   nodejs-16-20-1 = (
     let
-      nixpkgs = import inputs.nixpkgs-master-2023-07-18 {
-        inherit system;
-        config = {
-          permittedInsecurePackages = [ "nodejs-16.20.1" ];
-        };
-      };
+      nixpkgs = # 2023-07-18
+        (getFlake "github:nixos/nixpkgs/08700de174bc6235043cb4263b643b721d936bdb").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_16;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -69,12 +57,7 @@ rec {
 
   nodejs-16-20-2 = (
     let
-      nixpkgs = import inputs.nixpkgs-23-05 {
-        inherit system;
-        config = {
-          permittedInsecurePackages = [ "nodejs-16.20.2" ];
-        };
-      };
+      nixpkgs = inputs.nixpkgs-23-05.legacyPackages.${system};
       nodejs = nixpkgs.nodejs_16;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };

--- a/main/nodejs/v18.nix
+++ b/main/nodejs/v18.nix
@@ -1,13 +1,7 @@
 { inputs, system, ... }:
 let
-  inherit
-    (import inputs.nixpkgs-stable {
-      inherit system;
-      config = { };
-    })
-    symlinkJoin
-    runCommand
-    ;
+  inherit (builtins) getFlake;
+  inherit (inputs.nixpkgs-stable.legacyPackages.${system}) symlinkJoin runCommand;
 in
 rec {
   nodejs-18-x = nodejs-18-20-x;
@@ -19,10 +13,8 @@ rec {
 
   nodejs-18-17-1 = (
     let
-      nixpkgs = import inputs.nixpkgs-master-2023-09-15 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2023-09-15
+        (getFlake "github:nixos/nixpkgs/46688f8eb5cd6f1298d873d4d2b9cf245e09e88e").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_18;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -45,10 +37,8 @@ rec {
 
   nodejs-18-18-0 = (
     let
-      nixpkgs = import inputs.nixpkgs-unstable-2023-10-21 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2023-10-21
+        (getFlake "github:nixos/nixpkgs/038b2922be3fc096e1d456f93f7d0f4090628729").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_18;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -71,10 +61,8 @@ rec {
 
   nodejs-18-19-1 = (
     let
-      nixpkgs = import inputs.nixpkgs-unstable-2024-04-03 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2024-04-03
+        (getFlake "github:nixos/nixpkgs/62e885a4013446453b10fd7780eba4337f6f42e0").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_18;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -97,10 +85,8 @@ rec {
 
   nodejs-18-20-2 = (
     let
-      nixpkgs = import inputs.nixpkgs-unstable-2024-05-30 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2024-05-30
+        (getFlake "github:nixos/nixpkgs/aa61b27554a5fc282758bf0324781e3464ef2cde").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_18;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };

--- a/main/nodejs/v20.nix
+++ b/main/nodejs/v20.nix
@@ -1,13 +1,7 @@
 { inputs, system, ... }:
 let
-  inherit
-    (import inputs.nixpkgs-stable {
-      inherit system;
-      config = { };
-    })
-    symlinkJoin
-    runCommand
-    ;
+  inherit (builtins) getFlake;
+  inherit (inputs.nixpkgs-stable.legacyPackages.${system}) symlinkJoin runCommand;
 in
 rec {
   nodejs-20-x = nodejs-20-11-x;
@@ -16,10 +10,8 @@ rec {
 
   nodejs-20-11-0 = (
     let
-      nixpkgs = import inputs.nixpkgs-master-2024-01-27 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2024-01-27
+        (getFlake "github:nixos/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_20;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };
@@ -42,10 +34,8 @@ rec {
 
   nodejs-20-11-1 = (
     let
-      nixpkgs = import inputs.nixpkgs-unstable-2024-02-20 {
-        inherit system;
-        config = { };
-      };
+      nixpkgs = # 2024-02-20
+        (getFlake "github:nixos/nixpkgs/b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa").legacyPackages.${system};
       nodejs = nixpkgs.nodejs_20;
       yarn = nixpkgs.yarn.override { inherit nodejs; };
       pnpm = nixpkgs.nodePackages.pnpm.override { inherit nodejs; };

--- a/main/packages.nix
+++ b/main/packages.nix
@@ -1,9 +1,6 @@
 { inputs, system }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   flattenAttrs = nixpkgs.lib.lists.foldl' (a: b: a // b) { };
   files = [
     ./aws-cli/packages.nix

--- a/main/prettier/checks.nix
+++ b/main/prettier/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/prettier/packages.nix
+++ b/main/prettier/packages.nix
@@ -5,34 +5,13 @@ rec {
   prettier-2-x = prettier-2-8-x;
 
   prettier-2-8-x = prettier-2-8-8;
-  prettier-2-8-8 =
-    let
-      nixpkgs = import inputs.nixpkgs-23-05 {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.nodePackages.prettier;
+  prettier-2-8-8 = inputs.nixpkgs-23-05.legacyPackages.${system}.nodePackages.prettier;
 
   prettier-3-x = prettier-3-2-x;
 
   prettier-3-0-x = prettier-3-0-3;
-  prettier-3-0-3 =
-    let
-      nixpkgs = import inputs.nixpkgs-23-11 {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.nodePackages.prettier;
+  prettier-3-0-3 = inputs.nixpkgs-23-11.legacyPackages.${system}.nodePackages.prettier;
 
   prettier-3-2-x = prettier-3-2-5;
-  prettier-3-2-5 =
-    let
-      nixpkgs = import inputs.nixpkgs-stable {
-        inherit system;
-        config = { };
-      };
-    in
-    nixpkgs.nodePackages.prettier;
+  prettier-3-2-5 = inputs.nixpkgs-stable.legacyPackages.${system}.nodePackages.prettier;
 }

--- a/main/stack-lint-extra-deps/checks.nix
+++ b/main/stack-lint-extra-deps/checks.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  nixpkgs = import inputs.nixpkgs-stable {
-    inherit system;
-    config = { };
-  };
+  nixpkgs = inputs.nixpkgs-stable.legacyPackages.${system};
   inherit (nixpkgs) writeText runCommand;
   inherit (nixpkgs.lib.attrsets) recursiveUpdate;
   inherit (nixpkgs.testers) testEqualContents;

--- a/main/stack-lint-extra-deps/packages.nix
+++ b/main/stack-lint-extra-deps/packages.nix
@@ -1,6 +1,6 @@
 { inputs, system, ... }:
 let
-  nixpkgs = import inputs.nixpkgs-24-11 { inherit system; };
+  nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
   inherit (nixpkgs.haskell.lib) justStaticExecutables;
   inherit (builtins) getFlake;
 in


### PR DESCRIPTION
As mentioned in #101 I don't think we're getting anything out of the indirection of defining pinned nixpkgs versions as inputs in `flake.nix`, when we could be using `getFlake` at the use site instead. This cleans up the rest of the list. Dates input names are converted to code comments, just to leave us with a rough sense of how old pinned inputs are.

Also I finally figured out that `import inputs.foo { inherit system; config = {}; }` can be simplified to `inputs.foo.legacyPackages.${system}`, so that's done everywhere. (The name "legacy packages" is terrible and misleading, it's just the contents of nixpkgs.)

Configuration of `permittedInsecurePackages` is removed everywhere, as I couldn't figure out how to do it this way, and it was a bad idea to begin with. You should have to set the `NIXPKGS_ALLOW_INSECURE` env var to use packages with known vulnerabilities; this repo should not disable that security feature. The `NIXPKGS_ALLOW_INSECURE` var is set in CI now, to allow us to build insecure packages; it's up to the user of the flake to decide if they want to also enable `NIXPKGS_ALLOW_INSECURE` in order to use them.