### PR TITLE
enable HLS for ghc 9.8.4

### DIFF
--- a/main/flake.lock
+++ b/main/flake.lock
@@ -232,11 +232,11 @@
     },
     "nixpkgs-haskell-updates": {
       "locked": {
-        "lastModified": 1735305932,
-        "narHash": "sha256-8S/w2zulM/HQUtp30qFBvHUU1CzMg7f4tQoWTLtPU8s=",
+        "lastModified": 1735776984,
+        "narHash": "sha256-b8JNoUx6NKpsIlCNpKi6xAU2EupGDfIS7fUnj24mDeU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "542c92b9a536350375e4ab63bced85fdc963736a",
+        "rev": "c1bd49b1f33d146d3dfb1a56ad50e17c1f37d03f",
         "type": "github"
       },
       "original": {

--- a/main/ghc/checks.nix
+++ b/main/ghc/checks.nix
@@ -136,6 +136,7 @@ in
     packageName = "ghc-9-8-4";
     ghc = "9.8.4";
     weeder = "2.9.0";
+    hls = "2.9.0.0";
   };
   ghc-9-10-1 = ghcCheck {
     packageName = "ghc-9-10-1";


### PR DESCRIPTION
Closes #104, sets us up to move projects to [lts-23](https://www.stackage.org/lts-23)