### PR TITLE
upgrade the ghc 9.8 series

### DIFF
--- a/main/ghc/checks.nix
+++ b/main/ghc/checks.nix
@@ -118,25 +118,25 @@ in
     packageName = "ghc-9-8-1";
     ghc = "9.8.1";
     weeder = "2.9.0";
-    hls = "2.9.0.0";
+    hls = "2.10.0.0";
   };
   ghc-9-8-2 = ghcCheck {
     packageName = "ghc-9-8-2";
     ghc = "9.8.2";
     weeder = "2.9.0";
-    hls = "2.9.0.0";
+    hls = "2.10.0.0";
   };
   ghc-9-8-3 = ghcCheck {
     packageName = "ghc-9-8-3";
     ghc = "9.8.3";
     weeder = "2.9.0";
-    hls = "2.9.0.0";
+    hls = "2.10.0.0";
   };
   ghc-9-8-4 = ghcCheck {
     packageName = "ghc-9-8-4";
     ghc = "9.8.4";
     weeder = "2.9.0";
-    hls = "2.9.0.0";
+    hls = "2.10.0.0";
   };
   ghc-9-10-1 = ghcCheck {
     packageName = "ghc-9-10-1";

--- a/main/ghc/configurations.nix
+++ b/main/ghc/configurations.nix
@@ -267,7 +267,7 @@ in
   ghc-9-8-1 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
+      nixpkgs = inputs.nixpkgs-25-05.legacyPackages.${system};
       name = "ghc981";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -291,7 +291,7 @@ in
   ghc-9-8-2 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
+      nixpkgs = inputs.nixpkgs-25-05.legacyPackages.${system};
       name = "ghc982";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -315,7 +315,7 @@ in
   ghc-9-8-3 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
+      nixpkgs = inputs.nixpkgs-25-05.legacyPackages.${system};
       name = "ghc983";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};
@@ -339,8 +339,7 @@ in
   ghc-9-8-4 =
     { packageSelection, enableHLS }:
     let
-      nixpkgs = # 2025-01-03
-        (getFlake "github:nixos/nixpkgs/d3780c92e64472e8f9aa54f7bbb0dd4483b98303").legacyPackages.${system};
+      nixpkgs = inputs.nixpkgs-25-05.legacyPackages.${system};
       name = "ghc984";
       inherit (nixpkgs) haskell;
       haskellPackages = haskell.packages.${name};


### PR DESCRIPTION
Gets GHC 9.8 from NixOS 25.05; upgrades HLS.