### PR TITLE
update SLED, work around version thing, stop fetching latest

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,7 +25,6 @@ jobs:
           - nixpkgs-24-11
           - nixpkgs-25-05
           - nixpkgs-haskell-updates
-          - stack-lint-extra-deps
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31

--- a/main/flake.lock
+++ b/main/flake.lock
@@ -242,22 +242,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-haskell-updates_2": {
-      "locked": {
-        "lastModified": 1742210880,
-        "narHash": "sha256-bFR9Tthdaz1mR/IzdtHgzPuw5nEHn49AWay8iUqFEPM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1f00f46d8b14f6956005ab80f2e0e9c875d0dace",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "haskell-updates",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1736200483,
@@ -287,38 +271,6 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1742136038,
-        "narHash": "sha256-DDe16FJk18sadknQKKG/9FbwEro7A57tg9vB5kxZ8kY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a1185f4064c18a5db37c5c84e5638c78b46e3341",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pgp-wordlist": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714149562,
-        "narHash": "sha256-WCFQgtWqq+gLst4lXkFYlmlW7L8PQOJfChsKMApy3Ng=",
-        "owner": "quchen",
-        "repo": "pgp-wordlist",
-        "rev": "1f0cfd90d62179952cbfd59c3405283a1d364272",
-        "type": "github"
-      },
-      "original": {
-        "owner": "quchen",
-        "repo": "pgp-wordlist",
         "type": "github"
       }
     },
@@ -354,44 +306,7 @@
         "nixpkgs-24-11": "nixpkgs-24-11",
         "nixpkgs-25-05": "nixpkgs-25-05",
         "nixpkgs-haskell-updates": "nixpkgs-haskell-updates",
-        "nixpkgs-stable": "nixpkgs-stable",
-        "stack-lint-extra-deps": "stack-lint-extra-deps"
-      }
-    },
-    "stack-lint-extra-deps": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-haskell-updates": "nixpkgs-haskell-updates_2",
-        "pgp-wordlist": "pgp-wordlist",
-        "stacklock2nix": "stacklock2nix"
-      },
-      "locked": {
-        "lastModified": 1744218263,
-        "narHash": "sha256-DZg4hwzEe63oiaFRxyH2ek08cOVDrrFXpU2HzbtJE4I=",
-        "owner": "freckle",
-        "repo": "stack-lint-extra-deps",
-        "rev": "3ccabc07f47e244ee42d9841774739849d69cd78",
-        "type": "github"
-      },
-      "original": {
-        "owner": "freckle",
-        "repo": "stack-lint-extra-deps",
-        "type": "github"
-      }
-    },
-    "stacklock2nix": {
-      "locked": {
-        "lastModified": 1741332755,
-        "narHash": "sha256-ZQlzcx4f2cx4CQBQzMvEwJEAWJrfZEdZrGY7Iu5L9MA=",
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "rev": "47dd3fb2827fc0868142ab41a7daeaec0a6ddda1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "type": "github"
+        "nixpkgs-stable": "nixpkgs-stable"
       }
     },
     "systems": {

--- a/main/flake.nix
+++ b/main/flake.nix
@@ -12,7 +12,6 @@
     nixpkgs-25-05.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-haskell-updates.url = "github:nixos/nixpkgs/haskell-updates";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.11";
-    stack-lint-extra-deps.url = "github:freckle/stack-lint-extra-deps";
   };
   outputs =
     inputs:

--- a/main/stack-lint-extra-deps/checks.nix
+++ b/main/stack-lint-extra-deps/checks.nix
@@ -23,5 +23,7 @@ in
 {
   stack-lint-extra-deps-1-2-2 = versionCheck "1.2.2.1" packages.stack-lint-extra-deps-1-2-2;
   stack-lint-extra-deps-1-2-5 = versionCheck "1.2.5.0" packages.stack-lint-extra-deps-1-2-5;
-  stack-lint-extra-deps-1-3-0 = versionCheck "1.3.0.1" packages.stack-lint-extra-deps-1-3-0;
+
+  # Version number gets weird at this point because it isn't in the source repo anymore
+  stack-lint-extra-deps-1-3-0 = versionCheck "1.0.0.0" packages.stack-lint-extra-deps-1-3-0;
 }

--- a/main/stack-lint-extra-deps/packages.nix
+++ b/main/stack-lint-extra-deps/packages.nix
@@ -1,6 +1,6 @@
 { inputs, system, ... }:
 let
-  nixpkgs = inputs.nixpkgs-24-11.legacyPackages.${system};
+  nixpkgs = inputs.nixpkgs-25-05.legacyPackages.${system};
   inherit (nixpkgs.haskell.lib) justStaticExecutables;
   inherit (builtins) getFlake;
 in
@@ -19,5 +19,6 @@ rec {
 
   stack-lint-extra-deps-1-3-0 =
     justStaticExecutables
-      inputs.stack-lint-extra-deps.packages.${system}.stack-lint-extra-deps;
+      (getFlake "github:freckle/stack-lint-extra-deps/v1.3.0.7")
+      .packages.${system}.stack-lint-extra-deps;
 }


### PR DESCRIPTION
Some further thought is required to get `stack-lint-extra-deps` to work as desired here because the version number isn't in the source repo; see discussion in #181.

This PR:

- Updates our 1.3.0 package to the latest commit (which, looking at the [tags](https://github.com/freckle/stack-lint-extra-deps/tags), is 1.3.0.7)
- Removes the flake input that tracks the git `main` branch
- Changes the check to reflect the reality that `stack-lint-extra-deps --version` will now print `1.0.0.0` for this version
