### PR TITLE
Have Renovate use our shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "local>freckle/renovate-config"
+  ],
+  "minimumReleaseAge": "0 days"
 }


### PR DESCRIPTION
We have abnormal number of security issues in this repo. It looks like Renovate is not using our shared configuration: https://github.com/freckle/renovate-config/blob/main/default.json