### PR TITLE
Remove x86_64-darwin support from CI

### DIFF
--- a/main/flake.nix
+++ b/main/flake.nix
@@ -16,7 +16,6 @@
     let
       systems = [
         "x86_64-linux"
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
     in
@@ -38,7 +37,6 @@
         checks = inputs.nixpkgs-25-05.lib.getAttrs systems inputs.self.checks;
         platforms = {
           "x86_64-linux" = "ubuntu-24.04";
-          "x86_64-darwin" = "macos-13";
           "aarch64-darwin" = "macos-14";
         };
       };


### PR DESCRIPTION
## Summary
- Remove x86_64-darwin from the systems list and GitHub Actions matrix
- GitHub deprecated the macos-13 runner, causing Intel Mac jobs to not be picked up
- ARM64 Mac builds continue on macos-14

## Test plan
- [ ] CI passes on remaining platforms (ubuntu-24.04, macos-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)